### PR TITLE
Move user groups menu and fix variant linking

### DIFF
--- a/app/models/spree/backend_configuration_decorator.rb
+++ b/app/models/spree/backend_configuration_decorator.rb
@@ -1,0 +1,3 @@
+Spree::BackendConfiguration.class_eval do
+  USER_TABS ||= [:users, :user_groups]
+end

--- a/app/overrides/add_user_groups_to_configuration_menu.rb
+++ b/app/overrides/add_user_groups_to_configuration_menu.rb
@@ -1,4 +1,0 @@
-Deface::Override.new(:virtual_path  => "spree/admin/shared/sub_menu/_configuration",
-                     :name          => "add_user_groups_to_configuration_menu",
-                     :insert_bottom => "[data-hook='admin_configurations_sidebar_menu']",
-                     :text          => "<%= configurations_sidebar_menu_item Spree.t(:user_groups), spree.admin_user_groups_path %>")

--- a/app/overrides/add_user_groups_to_users_menu.rb
+++ b/app/overrides/add_user_groups_to_users_menu.rb
@@ -1,4 +1,5 @@
 Deface::Override.new(:virtual_path  => "spree/admin/shared/_main_menu",
                      :name          => "add_user_groups_to_users_menu",
                      :replace       => "erb[loud]:contains('tab *Spree::BackendConfiguration::USER_TABS')",
-                     :erb          => "<%= main_menu_tree Spree.t(:users), icon: 'user', sub_menu: 'user', url: '#sidebar-users'")
+                     :erb          => "<%= main_menu_tree Spree.t(:users), icon: 'user', sub_menu: 'user', url: '#sidebar-users'",
+                     :original     => "a020726e074f41b4214fe71cbaa3f62385eba146")

--- a/app/overrides/add_user_groups_to_users_menu.rb
+++ b/app/overrides/add_user_groups_to_users_menu.rb
@@ -1,0 +1,4 @@
+Deface::Override.new(:virtual_path  => "spree/admin/shared/_main_menu",
+                     :name          => "add_user_groups_to_users_menu",
+                     :replace       => "erb[loud]:contains('tab *Spree::BackendConfiguration::USER_TABS')",
+                     :erb          => "<%= main_menu_tree Spree.t(:users), icon: 'user', sub_menu: 'user', url: '#sidebar-users'")

--- a/app/views/spree/admin/shared/sub_menu/_user.html.erb
+++ b/app/views/spree/admin/shared/sub_menu/_user.html.erb
@@ -1,0 +1,4 @@
+<ul id="sidebar-users" class="collapse nav nav-pills nav-stacked" data-hook="admin_user_sub_tabs">
+  <%= tab :users %>
+  <%= tab :user_groups %>
+</ul>

--- a/app/views/spree/admin/user_groups/index.html.erb
+++ b/app/views/spree/admin/user_groups/index.html.erb
@@ -23,7 +23,7 @@
         <td class="align-center"><%= user_group.calculator_description %></td>
         <td class="align-center"><%= user_group.display_minimum_order %></td>
         <td data-hook="admin_user_groups_index_row_actions" class="actions">
-          <%= link_to_with_icon('dollar', Spree.t(:per_variant_pricing), pricing_admin_user_group_path(user_group.id), {:data => {:action => 'edit'}, :no_text => true}) if user_group.calculator.class == Spree::Calculator::PerVariantPricing %>
+          <%= link_to_with_icon('usd', Spree.t(:per_variant_pricing), pricing_admin_user_group_path(user_group.id), {:data => {:action => 'edit'}, class: 'btn btn-default btn-sm', :no_text => true}) if user_group.calculator.class == Spree::Calculator::PerVariantPricing %>
           <%= link_to_edit user_group, :no_text => true %>
           <%= link_to_delete user_group, :no_text => true %>
       </tr>

--- a/app/views/spree/admin/user_groups/index.html.erb
+++ b/app/views/spree/admin/user_groups/index.html.erb
@@ -23,7 +23,7 @@
         <td class="align-center"><%= user_group.calculator_description %></td>
         <td class="align-center"><%= user_group.display_minimum_order %></td>
         <td data-hook="admin_user_groups_index_row_actions" class="actions">
-          <%= link_to_with_icon('dollar', Spree.t(:per_variant_pricing), "/admin/user_groups/#{user_group.id}/pricing", {:data => {:action => 'edit'}, :no_text => true}) if user_group.calculator.class == Spree::Calculator::PerVariantPricing %>
+          <%= link_to_with_icon('dollar', Spree.t(:per_variant_pricing), pricing_admin_user_group_path(user_group.id), {:data => {:action => 'edit'}, :no_text => true}) if user_group.calculator.class == Spree::Calculator::PerVariantPricing %>
           <%= link_to_edit user_group, :no_text => true %>
           <%= link_to_delete user_group, :no_text => true %>
       </tr>


### PR DESCRIPTION
Small PR that:
1. Fixes per variant link so it is visible in menu (see below)
2. Fixes per variant link for Spree that is not mounted at root (by using path)
3. Moves User Groups under the Users menu in Admin (I think it makes more sense there)

![spree_administration__user_groups](https://cloud.githubusercontent.com/assets/756029/8527898/882a8cd0-23cc-11e5-9ebf-913b01c2e7f5.png)
